### PR TITLE
Zero out the default artwork margin.

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3,4 +3,5 @@ body {
 
   /* leave it to hide the scrollbars */
   overflow: hidden;
+  margin: 0;
 }


### PR DESCRIPTION
Add zero margin to boilerplate CSS to avoid the 8px default margin when reloading artwork.